### PR TITLE
Removed --load option which causes build error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,10 +55,6 @@ else
     echo "Build container for ${platform_arg}"
 fi
 
-if [[ -z "${platform_arg}" ]]; then
-    args+=("--load")
-fi
-
 if [[ -z "${push_container_arg}" ]]; then
     args+=("--push")
 fi


### PR DESCRIPTION
When running `build.sh` on Linux, it tries to build for arch "linux/amd64,linux/arm64" by default, and also uses `--load`. This causes a build error:
```
ERROR: failed to build: docker exporter does not currently support exporting manifest lists
```

I don't see the purpose of the `--load` option, so I'm removing it here. If there is a purpose please let me know, maybe there is a better way to resolve this. 